### PR TITLE
Use Storage Device's UUID In /etc/fstab

### DIFF
--- a/storage.tf
+++ b/storage.tf
@@ -38,9 +38,9 @@ resource "null_resource" "host_attachment_commands" {
       "if ! sudo blkid ${var.vms_host_device_name}; then sudo mkfs.${var.vms_filesystem_type} ${var.vms_host_device_name}; fi",
       "sudo mkdir -p ${var.vms_mount_point}",
       "sudo mount ${var.vms_host_device_name} ${var.vms_mount_point}",
-      "sudo sed -i '/.*${replace(var.vms_host_device_name, "/", "\\/")}.*/d' /etc/fstab",
       "sudo sed -i '/.*${replace(var.vms_mount_point, "/", "\\/")}.*/d' /etc/fstab",
-      "sudo bash -c 'echo \"${var.vms_host_device_name}\t${var.vms_mount_point}\t${var.vms_filesystem_type}\t${var.vms_fstab_mount_options}\" >> /etc/fstab'"
+      "sudo bash -c 'uuid=$(lsblk -n -o UUID ${var.vms_host_device_name}) && sed -i \"/$uuid/d\" /etc/fstab",
+      "sudo bash -c 'uuid=$(lsblk -n -o UUID ${var.vms_host_device_name}) && echo \"UUID=$uuid\t${var.vms_mount_point}\t${var.vms_filesystem_type}\t${var.vms_fstab_mount_options}\" >> /etc/fstab'"
     ]
 
   }


### PR DESCRIPTION
Instead of using the path to the device in /dev/, use the device's
UUID since the /dev path might change.

Signed-off-by: Jason Rogena <jason@rogena.me>